### PR TITLE
Upgrade convert from v2 to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -521,9 +521,9 @@
             "dev": true
         },
         "convert": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/convert/-/convert-2.1.1.tgz",
-            "integrity": "sha512-96U6MR3u6oQ73IQM07JN6w+MWKdrsj7N4z+XyX65CXNTD+osJYbIZbW81S1wGluud6SoPlVch6gKe+2P5IIkuA==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/convert/-/convert-4.1.3.tgz",
+            "integrity": "sha512-xu5iZrDpGYN4dqdNRKkAlDauqOkj7+dzjDuLT6tnuILaLkPxYnRH4aQEgXpFaWQiG7d+TsKiuke1ovIxNKmaSQ==",
             "dev": true
         },
         "convert-units": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@types/sprintf-js": "^1.1.2",
         "@typescript-eslint/eslint-plugin": "^4.28.1",
         "@typescript-eslint/parser": "^4.28.1",
-        "convert": "^2.1.1",
+        "convert": "^4.1.3",
         "convert-units": "^2.3.4",
         "eslint": "^7.29.0",
         "source-map-support": "^0.5.19",


### PR DESCRIPTION
Upgrades `convert` from v2 to v4. Specifically to v4.1.3, which fixes a bug that caused projects like yours to stop compiling. If you run `tsc` now you shouldn't get any compiler errors from my package. Sorry about that!

By the way, you may find [my benchmark repo](https://github.com/jonahsnider/js-unit-conversion-benchmarks) interesting for tracking the performance of various unit conversion libraries. Once this library is published I'll include it in my benchmarks.

Also, if this was helpful to you I'd appreciate if you marked this PR/repo as opted-in for Hacktoberfest by adding the `hacktoberfest-accepted` label to this PR or adding the `hacktoberfest` label to the repo. Thanks!